### PR TITLE
remove extraneous dependency on future

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -15,4 +15,3 @@ mmcif_pdbx
 svglib
 pyfai ; python_version > '2.7'
 pyfai == 0.17; python_version == '2.7'
-future; python_version == '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ mmcif_pdbx
 svglib
 pyfai ; python_version > '2.7'
 pyfai == 0.17; python_version == '2.7'
-future; python_version == '2.7'
 dbus-python; platform_system == 'Linux'

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         'svglib',
         'pyfai;python_version>"2.7"',
         'pyfai==0.17;python_version=="2.7"',
-        'future;python_version=="2.7"',
         'dbus-python;platform_system=="Linux"',
         ],
     ext_modules=cythonize("bioxtasraw/sascalc_exts.pyx",


### PR DESCRIPTION
Hi,

There seems to have been a misunderstanding years ago:
`from __future__ import xyz` and `from future import xyz`
is not the same thing.

`__future__' doesn't need any external dependency.

`future` has incompatibilites with Python3.12
and has just plainly outlived is usefullness and is being removed from Debian

So this PR remove this extraneous dependency while keeping Py2.7 compatibility.
