### PR TITLE
import setuptools for successful pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,18 +10,20 @@ elif six.PY3:
 else:
     language_level = None
 
-opsys = platform.system()
+from setuptools import setup, Extension, find_packages
 
-if opsys == 'Windows':
-    try:
-        from setuptools import setup, find_packages
-        from setuptools import Extension
-    except ImportError:
-        from distutils.core import setup, find_packages
-        from distutils.extension import Extension
-else:
-    from distutils.core import setup, find_packages
-    from distutils.extension import Extension
+# opsys = platform.system()
+
+# if opsys == 'Windows':
+#     try:
+#         from setuptools import setup
+#         from setuptools import Extension
+#     except ImportError:
+#         from distutils.core import setup
+#         from distutils.extension import Extension
+# else:
+#     from distutils.core import setup
+#     from distutils.extension import Extension
 
 from Cython.Build import cythonize
 

--- a/setup.py
+++ b/setup.py
@@ -14,13 +14,13 @@ opsys = platform.system()
 
 if opsys == 'Windows':
     try:
-        from setuptools import setup
+        from setuptools import setup, find_packages
         from setuptools import Extension
     except ImportError:
-        from distutils.core import setup
+        from distutils.core import setup, find_packages
         from distutils.extension import Extension
 else:
-    from distutils.core import setup
+    from distutils.core import setup, find_packages
     from distutils.extension import Extension
 
 from Cython.Build import cythonize
@@ -43,7 +43,7 @@ setup(
     version=get_version('./bioxtasraw/__init__.py'),
     description='A package for processing biological small angle scattering data.',
     url="https://bioxtas-raw.readthedocs.io/en/latest/",
-    packages=['bioxtasraw'],
+    packages=find_packages(),
     install_requires=[
         'numpy',
         'scipy',


### PR DESCRIPTION
Install using conda and pip didn't work for me -- it failed to install the sub-package bioxtasraw.denss_resources. To fix it, I modified setup.py to use setuptools.find_packages. The goal here is to enable a one-line linux install like this:

```bash
micromamba create -f raw_env.yaml
```

With raw_env.yaml as follows:

```yaml
name: raw-2-2-2
channels:
  - conda-forge
dependencies:
  - python >=3.9,<3.10
  - numpy
  - scipy
  - matplotlib
  - pillow
  - numba
  - h5py
  - cython
  - reportlab
  - wxpython
  - dbus-python
  - fabio
  - pyfai
  - hdf5plugin
  - mmcif_pdbx
  - svglib
  - pip:
    - git+https://github.com/jbhopkins/bioxtasraw.git@v2.2.2
```